### PR TITLE
Add policy reports to publications

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,6 +285,16 @@ The package supports programmatic model definition. Once the model is defined, t
 
 					<h3 id="other">Policy work</h3>
 
+                                        <p>
+                                                <div style="padding-left:20px;"><b>Report on monetary policy tools, strategy and communication</b></div>
+                                                <div style="padding-left:33px;">Strategy Review - Workstream 2: Monetary Policy Tools, Strategy and Communication &middot <a href="https://www.ecb.europa.eu/pub/pdf/scpops/ecb.op372.en.pdf">ECB Occasional Paper No. 372 (2025)</a></div>
+                                        </p>
+
+                                        <p>
+                                                <div style="padding-left:20px;"><b>Interest rate risk exposures of nonfinancial corporates and households: Implications for monetary policy transmission and financial stability</b></div>
+                                                <div style="padding-left:33px;"><a href="https://www.bis.org/publ/cgfs70.pdf">BIS CGFS Paper No. 70 (2024)</a></div>
+                                        </p>
+
 					<p>
 						<div style="padding-left:20px;"><b >Corporate debt service and rollover risks in an environment of higher interest rates</b></div>
 							<div style="padding-left:33px;">with 


### PR DESCRIPTION
## Summary
- add links to BIS CGFS paper and ECB Occasional Paper in policy work section
- highlight Strategy Review context for ECB paper

## Testing
- `pdfinfo /tmp/op372.pdf | head -n 5`
- `pdfinfo /tmp/cgfs70.pdf | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68755c9abe7c832fb292841946c751a5