### PR TITLE
Add 2025 ECB working paper to research section

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,18 +143,31 @@ The package supports programmatic model definition. Once the model is defined, t
 
 
 						<h3 id="wp">Working papers</h3>
-					<p>
-						<details open style="padding-left:20px;" onclick="ga('send', 'event', 'contagion abstract', 'view', 'greenium abstract');">
-							<summary><b>Green and Brown Returns in a Production Economy</b><br>
-							<div style="padding-left:13px;">with <a href="https://sites.google.com/site/ivanjaccard/home">Ivan Jaccard</a>, and <a href="https://sites.google.com/site/yvesschueler">Yves Schüler</a></div>
-								
-							<div style="padding-left:13px;"><a href="https://www.ecb.europa.eu/pub/pdf/scpwps/ecb.wp3030~acb29d20cc.en.pdf">ECB Working Paper (2025)</a></div>
-							</summary>
-							<p class="abstract" align='justify'>
-							Does it pay to invest in green companies? In countries where a market for carbon is functioning, such as those within the European Union, our findings suggest that it should be beneficial. Using a sample of green and brown European firms, we initially demonstrate that green companies have outperformed brown ones in recent times. Subsequently, we develop a production economy model in which brown firms acquire permits to emit carbon into the atmosphere. We find that the presence of a well-functioning carbon market could account for the green equity premium observed in our data. Incorporating a preference for green financial assets is also unlikely to overturn our results.
-							</p>
-						</details>
-					</p>
+                                        <p>
+                                                <details open style="padding-left:20px;" onclick="ga('send', 'event', 'trade wars abstract', 'view', 'trade wars abstract');">
+                                                        <summary><b>Trade wars and global spillovers. A quantitative assessment with ECB-global</b><br>
+                                                        <div style="padding-left:13px;">with <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/valentin-jouvanceau.en.html">Valentin Jouvanceau</a>, <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/matthieu-darracq-paries.en.html">Matthieu Darracq Pariès</a>, and <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/alistair-dieppe.en.html">Alistair Dieppe</a></div>
+
+                                                        <div style="padding-left:13px;"><a href="https://www.ecb.europa.eu/pub/pdf/scpwps/ecb.wp3117~d7d3c84989.en.pdf">ECB Working Paper (2025)</a></div>
+                                                        </summary>
+                                                        <p class="abstract" align='justify'>
+                                                        This paper examines the macroeconomic impact of substantial tariffs imposed by the second Trump administration on imports from China and the euro area and their transmission through direct and indirect channels. Using the ECB-Global 3.0 semi-structural model, we show that tariffs raise US import prices and lead to tighter US monetary policy, with the managed float of the renminbi partly offsetting adverse effects in China, while appreciation of the dollar undermines US export competitiveness. In the euro area, euro depreciation provides limited output support but intensifies imported inflation and triggers additional policy tightening. We assess the sensitivity of these results to key assumptions, such as the global amplification of inflation via dominant US dollar invoicing, partial trade diversion, and alternative monetary policy frameworks that attenuate monetary tightening and output contraction. Quantitative assessments of tariffs enacted up to 26 May 2025 and of an escalation scenario indicate significant global output losses and heightened inflationary pressures, requiring widespread policy rate increases. Further escalation of the trade conflict magnifies these effects, highlighting the challenges central banks face in navigating the trade-off between price stability and growth.
+                                                        </p>
+                                                </details>
+                                        </p>
+
+                                        <p>
+                                                <details style="padding-left:20px;" onclick="ga('send', 'event', 'contagion abstract', 'view', 'greenium abstract');">
+                                                        <summary><b>Green and Brown Returns in a Production Economy</b><br>
+                                                        <div style="padding-left:13px;">with <a href="https://sites.google.com/site/ivanjaccard/home">Ivan Jaccard</a>, and <a href="https://sites.google.com/site/yvesschueler">Yves Schüler</a></div>
+
+                                                        <div style="padding-left:13px;"><a href="https://www.ecb.europa.eu/pub/pdf/scpwps/ecb.wp3030~acb29d20cc.en.pdf">ECB Working Paper (2025)</a></div>
+                                                        </summary>
+                                                        <p class="abstract" align='justify'>
+                                                        Does it pay to invest in green companies? In countries where a market for carbon is functioning, such as those within the European Union, our findings suggest that it should be beneficial. Using a sample of green and brown European firms, we initially demonstrate that green companies have outperformed brown ones in recent times. Subsequently, we develop a production economy model in which brown firms acquire permits to emit carbon into the atmosphere. We find that the presence of a well-functioning carbon market could account for the green equity premium observed in our data. Incorporating a preference for green financial assets is also unlikely to overturn our results.
+                                                        </p>
+                                                </details>
+                                        </p>
 
 					<p>
 						<details  style="padding-left:20px;" onclick="ga('send', 'event', 'contagion abstract', 'view', 'contagion abstract');">


### PR DESCRIPTION
## Summary
- add the 2025 ECB Working Paper Series No. 3117 entry to the Working papers list
- include co-author information, PDF link, and abstract details
- keep the previous working paper entry collapsed so the newest one is open by default

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5464d78f8832fac50c1eb84cb7020