### PR TITLE
Ensure external links open in new tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ The package supports programmatic model definition. Once the model is defined, t
                                         <p>
                                                 <details open style="padding-left:20px;" onclick="ga('send', 'event', 'trade wars abstract', 'view', 'trade wars abstract');">
                                                         <summary><b>Trade wars and global spillovers. A quantitative assessment with ECB-global</b><br>
-                                                        <div style="padding-left:13px;">with <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/valentin-jouvanceau.en.html">Valentin Jouvanceau</a>, <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/matthieu-darracq-paries.en.html">Matthieu Darracq Pariès</a>, and <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/alistair-dieppe.en.html">Alistair Dieppe</a></div>
+                                                        <div style="padding-left:13px;">with <a href="https://sites.google.com/site/valentinjouvanceau/homepage">Valentin Jouvanceau</a>, <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/matthieu-darracq-paries.en.html">Matthieu Darracq Pariès</a>, and <a href="https://www.ecb.europa.eu/pub/research/authors/profiles/alistair-dieppe.en.html">Alistair Dieppe</a></div>
 
                                                         <div style="padding-left:13px;"><a href="https://www.ecb.europa.eu/pub/pdf/scpwps/ecb.wp3117~d7d3c84989.en.pdf">ECB Working Paper (2025)</a></div>
                                                         </summary>
@@ -297,7 +297,30 @@ The most effective remedy, according to our simulations, is to increase the bank
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-		<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+                <script>
+                        document.addEventListener('DOMContentLoaded', function () {
+                                var externalLinks = document.querySelectorAll('a[href^="http"]');
+                                externalLinks.forEach(function (link) {
+                                        var linkUrl;
+                                        try {
+                                                linkUrl = new URL(link.href);
+                                        } catch (error) {
+                                                return;
+                                        }
+
+                                        if (linkUrl.hostname !== window.location.hostname) {
+                                                link.setAttribute('target', '_blank');
+
+                                                var relValue = link.getAttribute('rel') || '';
+                                                if (!/\bnoopener\b/.test(relValue)) {
+                                                        relValue = (relValue + ' noopener').trim();
+                                                        link.setAttribute('rel', relValue);
+                                                }
+                                        }
+                                });
+                        });
+                </script>
+                <script type="text/javascript" src="https://www.google.com/jsapi"></script>
                 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
                 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
 		<script type="text/javascript" src="static/js/retina.js"></script>

--- a/workshop.html
+++ b/workshop.html
@@ -114,7 +114,30 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-		<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+            <script>
+                    document.addEventListener('DOMContentLoaded', function () {
+                            var externalLinks = document.querySelectorAll('a[href^="http"]');
+                            externalLinks.forEach(function (link) {
+                                    var linkUrl;
+                                    try {
+                                            linkUrl = new URL(link.href);
+                                    } catch (error) {
+                                            return;
+                                    }
+
+                                    if (linkUrl.hostname !== window.location.hostname) {
+                                            link.setAttribute('target', '_blank');
+
+                                            var relValue = link.getAttribute('rel') || '';
+                                            if (!/\bnoopener\b/.test(relValue)) {
+                                                    relValue = (relValue + ' noopener').trim();
+                                                    link.setAttribute('rel', relValue);
+                                            }
+                                    }
+                            });
+                    });
+            </script>
+            <script type="text/javascript" src="https://www.google.com/jsapi"></script>
             <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
             <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
 		<script type="text/javascript" src="static/js/retina.js"></script>


### PR DESCRIPTION
## Summary
- update the Valentin Jouvanceau link to point to his personal website
- add a script that forces external links to open in a new tab while preserving noopener for security
- apply the same external link handling to the workshop page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5765e267c832fa5778a9e673daa84